### PR TITLE
use "label" for validation error messages when avaliable, make sure they are translated properly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vee-element",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7508,11 +7508,6 @@
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.0.tgz",
       "integrity": "sha512-o3WmXySo+oI5thgqr7Qy8uBkT/v9Zr+sRyrh1lr8aWPUkgDWdWt4Nae2WKBrLsocgE8BuWWD0jLc+VW8LeU+2g==",
       "dev": true
-    },
-    "vue-router": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.0.1.tgz",
-      "integrity": "sha512-vLLoY452L+JBpALMP5UHum9+7nzR9PeIBCghU9ZtJ1eWm6ieUI8Zb/DI3MYxH32bxkjzYV1LRjNv4qr8d+uX/w=="
     },
     "w3c-hr-time": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vee-element",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "description": "Replaces Element UI's validation engine with Vee Validate",
   "author": "Dave Stewart",
   "homepage": "https://davestewart.github.io/vee-element/",

--- a/src/drivers/vee.js
+++ b/src/drivers/vee.js
@@ -26,6 +26,7 @@ export default class VeeDriver {
         // variables
         const prop = this.prop
         const error = errors[0]
+        const label = (this.label) ? this.label : this.prop
 
         // generate error messages
         const theField = 'The {field} field'
@@ -34,7 +35,7 @@ export default class VeeDriver {
           ? error.replace(theField, thisField)
           : ''
         const errorForm = error
-          ? error.replace('{field}', `"${prop}"`)
+          ? error.replace('{field}', `"${label}"`)
           : null
         const invalidFields = {}
         if (!valid) {
@@ -47,7 +48,7 @@ export default class VeeDriver {
 
         // update
         this.validateState = valid ? 'success' : 'error'
-        this.validateMessage = errorField
+        this.validateMessage = errorForm
 
         // respond
         callback(errorForm, invalidFields)


### PR DESCRIPTION
Hey there, thanks for your great plugin, happily using it on a project currently.
Only when also integrating i18n, there was a small issue that needed fixing.

* issue: when using the localize feature of `vee-validate` the `{field}` text was displayed without being replaced.
* solution: this seemed due to a mixup in `validateMessage` assignment
* extension: finally, most field names are usually cryptic and not user-friendly, so i also added a logic for using the "label" instead of the "prop" value in case it is defined
* result: instead of `"companyName" is a required field`, we will get to see `"Your Company's Name" is a required field`

Feel free to only use this as inspiration, as there are no proper tests etc. attached to this.
Also, this is based on me playing around with the compiles `.esm.js` Version that is used in our project.

One final though / wish while we're at it: Do you plan on doing versioned releases soon? If so, something like [`release-it`](https://github.com/webpro/release-it) might help make things easier for you.

Thanks