### PR TITLE
Error translating `The {field} field...`

### DIFF
--- a/src/drivers/vee.js
+++ b/src/drivers/vee.js
@@ -28,8 +28,10 @@ export default class VeeDriver {
         const error = errors[0]
 
         // generate error messages
-        const theField = 'The {field} field'
-        const thisField = validator.dictionary.getAttribute(validator.dictionary.locale, theField) || 'This field'
+        const THE_FIELD = 'The {field} field';
+        const THIS_FIELD = 'This field';
+        const theField = validator.dictionary.getAttribute(validator.dictionary.locale, THE_FIELD) || THE_FIELD;
+        const thisField = validator.dictionary.getAttribute(validator.dictionary.locale, THIS_FIELD) || THIS_FIELD;
         const errorField = error
           ? error.replace(theField, thisField)
           : ''


### PR DESCRIPTION
When translating to french from `The {field} field...` to `This field...`
the result is `Le champ {filed}...` but should be `Ce champ...`.

The `error.replace(theField, thisField)` can't find the good substring.

With this proposal, it work's fine when using the followings `attributes` for the french dictionnary :
```js
attributes: {
  'The {field} field': 'Le champ {field}',
  'This field': 'Ce champ',
}
```

It still works fine for english default translation.