### PR TITLE
Fix "this.getDriver is not a function", update error message passing, other minor fixes

### DIFF
--- a/demo/src/main.js
+++ b/demo/src/main.js
@@ -8,7 +8,7 @@ import locale from 'element-ui/lib/locale/lang/en'
 import 'element-ui/lib/theme-chalk/index.css'
 
 // vee element
-import VeeElement from 'vee-element'
+import VeeElement from '../../src/main'
 import validator from './config/validator'
 
 // plugins

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vee-element",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.5",
   "description": "Replaces Element UI's validation engine with Vee Validate",
   "author": "Dave Stewart",
   "homepage": "https://davestewart.github.io/vee-element/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vee-element",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "description": "Replaces Element UI's validation engine with Vee Validate",
   "author": "Dave Stewart",
   "homepage": "https://davestewart.github.io/vee-element/",
@@ -45,6 +45,7 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
     "jest": "^23.4.1",
+    "rollup": "^1.17.0",
     "rollup-plugin-buble": "^0.19.1",
     "rollup-plugin-commonjs": "^8.4.1",
     "rollup-plugin-license": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dev": "rollup -c build/rollup.js -w",
     "build": "rollup -c build/rollup.js",
     "demo": "cd demo && npm run serve",
+    "prepare": "npm run build",
     "lint": "./node_modules/.bin/eslint src/*",
     "test": "jest --watchAll --verbose",
     "unit": "jest --config jest.config.js --coverage"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "dev": "rollup -c build/rollup.js -w",
     "build": "rollup -c build/rollup.js",
-    "demo": "cd demo && npm run dev",
+    "demo": "cd demo && npm run serve",
     "lint": "./node_modules/.bin/eslint src/*",
     "test": "jest --watchAll --verbose",
     "unit": "jest --config jest.config.js --coverage"

--- a/src/drivers/vee.js
+++ b/src/drivers/vee.js
@@ -18,26 +18,22 @@ export default class VeeDriver {
       callback()
     }
 
+    const verifyOptions = {
+      name: this.label,
+    }
+
     // this.validateState = 'validating'
     const validator = driver.validator
     validator
-      .verify(this.fieldValue, rules)
+      .verify(this.fieldValue, rules, verifyOptions)
       .then(({ valid, errors }) => {
         // variables
         const prop = this.prop
         const error = errors[0]
 
         // generate error messages
-        const THE_FIELD = 'The {field} field';
-        const THIS_FIELD = 'This field';
-        const theField = validator.dictionary.getAttribute(validator.dictionary.locale, THE_FIELD) || THE_FIELD;
-        const thisField = validator.dictionary.getAttribute(validator.dictionary.locale, THIS_FIELD) || THIS_FIELD;
-        const errorField = error
-          ? error.replace(theField, thisField)
-          : ''
-        const errorForm = error
-          ? error.replace('{field}', `"${prop}"`)
-          : null
+        const errorField = error || ''
+        const errorForm = error || null
         const invalidFields = {}
         if (!valid) {
           invalidFields[prop] = [{

--- a/src/drivers/vee.js
+++ b/src/drivers/vee.js
@@ -54,11 +54,17 @@ export default class VeeDriver {
   }
 
   getRules () {
-    return this.rules
+    const rules = this.rules
       ? this.rules
       : this.prop
         ? get(this.form.rules, this.prop) || ''
         : ''
+
+    if (typeof rules === 'object' && !Array.isArray(rules)) {
+      Object.defineProperty(rules, 'length', { value: 1 })
+    }
+
+    return rules
   }
 
   getFilteredRule () {

--- a/src/main.js
+++ b/src/main.js
@@ -27,26 +27,26 @@ export default function (Vue, validator, asDefault = true) {
 
     computed: {
       isRequired () {
-        return this.getDriver().isRequired.apply(this)
+        return this.selectedDriver.isRequired.apply(this)
+      },
+
+      selectedDriver () {
+        return drivers[this.form.driver || defaultDriver]
       }
     },
 
     methods: {
-      getDriver () {
-        return drivers[this.form.driver || defaultDriver]
-      },
-
       validate (trigger, callback) {
-        const driver = this.getDriver()
+        const driver = this.selectedDriver
         return driver.validate.apply(this, [trigger, callback, driver]) // pass driver as 3rd argument to get around binding
       },
 
       getRules () {
-        return this.getDriver().getRules.apply(this)
+        return this.selectedDriver.getRules.apply(this)
       },
 
       getFilteredRule (trigger) {
-        return this.getDriver().getFilteredRule.apply(this, [trigger])
+        return this.selectedDriver.getFilteredRule.apply(this, [trigger])
       }
     }
   })

--- a/src/main.js
+++ b/src/main.js
@@ -7,46 +7,47 @@ export default function (Vue, validator, asDefault = true) {
   Vue.options.components.ElForm.options.props.driver = String
 
   // form item
-  const options = Vue.options.components.ElFormItem.options
+  const ElFormItem = Vue.options.components.ElFormItem
 
   // drivers
   const defaultDriver = asDefault
     ? 'vee'
     : 'async'
   const drivers = {
-    async: new AsyncDriver(options),
+    async: new AsyncDriver(ElFormItem.options),
     vee: new VeeDriver(validator),
   }
 
   // props
-  Object.assign(options.props, {
-    rules: [Object, String, Array],
-    driver: String
-  })
-
-  // computed
-  options.computed.isRequired = function () {
-    return this.getDriver().isRequired.apply(this)
-  }
-
-  // methods
-  Object.assign(options.methods, {
-
-    getDriver () {
-      return drivers[this.form.driver || defaultDriver]
+  Vue.options.components.ElFormItem = ElFormItem.extend({
+    props: {
+      rules: [Object, String, Array],
+      driver: String
     },
 
-    validate (trigger, callback) {
-      const driver = this.getDriver()
-      return driver.validate.apply(this, [trigger, callback, driver]) // pass driver as 3rd argument to get around binding
+    computed: {
+      isRequired () {
+        return this.getDriver().isRequired.apply(this)
+      }
     },
 
-    getRules () {
-      return this.getDriver().getRules.apply(this)
-    },
+    methods: {
+      getDriver () {
+        return drivers[this.form.driver || defaultDriver]
+      },
 
-    getFilteredRule (trigger) {
-      return this.getDriver().getFilteredRule.apply(this, [trigger])
+      validate (trigger, callback) {
+        const driver = this.getDriver()
+        return driver.validate.apply(this, [trigger, callback, driver]) // pass driver as 3rd argument to get around binding
+      },
+
+      getRules () {
+        return this.getDriver().getRules.apply(this)
+      },
+
+      getFilteredRule (trigger) {
+        return this.getDriver().getFilteredRule.apply(this, [trigger])
+      }
     }
   })
 }


### PR DESCRIPTION
- Fixes #10
- Remove modification of error message, instead pass the label, resulting in similar results to that of asyncValidator
- Other commits are self explanatory


Explanation -
The issue was caused because of some plugin extending the initial definition of the component using `ElFormItem.extend(options)` causing the initial definition (consisting of getDriver and other function overrides) to not be used. In cases like this, if you override `ElFormItem.extendedOptions` instead of `ElFormItem.options`, the issue fixes. 

Instead, as a more universal fix, I just used the extend method directly.